### PR TITLE
Extend the SvelteWindowProps with onsegmentready.

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -7,7 +7,7 @@ declare global {
 }
 
 declare namespace svelte.JSX {
-  interface HTMLProps<Window> {
-    segmentready?: EventHandler<Event, Window> | undefined;
+  interface SvelteWindowProps {
+    onsegmentready?: EventHandler<Event, Window> | undefined;
   }
 }


### PR DESCRIPTION
Close #15.

<a href="https://gitpod.io/#https://github.com/mikenikles/svelte-segment-events/pull/16"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

